### PR TITLE
tabInfo types - added Sandbox

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -300,6 +300,7 @@ interface TabInfoI {
   type:
     | "chat"
     | "new-tab"
+    | "sandbox"
     | "content"
     | "loading"
     | "profile"
@@ -371,6 +372,13 @@ interface TabInfo_content extends TabInfoI {
 }
 
 //* NOTE: This type was copied from multinite's tabManagerProvider.tsx
+interface TabInfo_sandbox extends TabInfoI {
+  type: "sandbox";
+  path: `/sandbox`;
+  tabProperties: {};
+}
+
+//* NOTE: This type was copied from multinite's tabManagerProvider.tsx
 interface TabInfo_profile extends TabInfoI {
   type: "profile";
   path: "/profile" | `/profile/@${string}`;
@@ -390,6 +398,7 @@ export type TabInfo =
   | TabInfo_loading
   | TabInfo_chat
   | TabInfo_public
+  | TabInfo_sandbox
   | TabInfo_profile
   | TabInfo_developers
   | TabInfo_calendar


### PR DESCRIPTION
### TL;DR

The `TabInfo` interface in /src/api/types.ts now includes 'sandbox' as a type of tab that an user can navigate to.

### What changed?

A new interface `TabInfo_sandbox` was added, containing properties specific to the 'sandbox' type. Furthermore, 'sandbox' was added to the possible values of the 'type' property in the `TabInfoI` interface.

### How to test?

Navigate to a sandbox tab using the modified interface. Ensure type-checking recognizes 'sandbox' as a valid type and tab-specific properties work as expected.

### Why make this change?

This change provides support for a new 'sandbox' tab in the application, enhancing user experiences and functionalities.

---

